### PR TITLE
Fix weekly reset counter

### DIFF
--- a/AI_Stock_Trading.py
+++ b/AI_Stock_Trading.py
@@ -158,6 +158,7 @@ class PortfolioManagementSystem(TradingSystem):
                 data=[[
                     data_req['IBM']['close'][0]]], columns='Close'.split()
             )
+            day_count += 1
             if(day_count == 7):
                 day_count = 0
                 last_weeks_close = this_weeks_close


### PR DESCRIPTION
## Summary
- increment `day_count` each loop iteration so the weekly reset triggers

## Testing
- `python -m py_compile AI_Stock_Trading.py`

------
https://chatgpt.com/codex/tasks/task_e_684317a99c70832a81bcbd06d664b43b