### PR TITLE
Fix typo in training comment

### DIFF
--- a/AI_Stock_Trading.py
+++ b/AI_Stock_Trading.py
@@ -55,7 +55,7 @@ class PMModelDevelopment:
         X = data['Delta Close']
         y = data.drop(['Delta Close'], axis=1)
 
-        # Train test spit
+        # Train test split
         X_train, X_test, y_train, y_test = train_test_split(X, y)
 
         # Create the sequential


### PR DESCRIPTION
## Summary
- fix a typo in the training comment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684317a38ed8832aa2570015adc9e229